### PR TITLE
Fix crash if Storage Drawers is not present + add SD compat to config

### DIFF
--- a/src/mrtjp/projectred/compatibility/storagedrawers/PluginStorageDrawers.scala
+++ b/src/mrtjp/projectred/compatibility/storagedrawers/PluginStorageDrawers.scala
@@ -14,7 +14,7 @@ import net.minecraft.inventory.IInventory
 
 object PluginStorageDrawers extends IPRPlugin
 {
-  override def getModIDs = Array("ProjRed|Transportation")
+  override def getModIDs = Array("StorageDrawers")
 
   override def isEnabled = Configurator.compat_StorageDrawers
 

--- a/src/mrtjp/projectred/core/Configurator.scala
+++ b/src/mrtjp/projectred/core/Configurator.scala
@@ -159,6 +159,7 @@ object Configurator extends ModConfig("ProjRed|Core")
         compat_CCBundledCalbe = compat.put("ComputerCraft: Bundled Cables", compat_CCBundledCalbe, "This allows computers to connect to bundled cables with the RS API")
         compat_ColoredLights = compat.put("ColoredLights Compat", compat_ColoredLights, "This makes things emit colored light. CLC is in beta state and may cause minor rendering glitches.")
         compat_MFRDeepStorage = compat.put("MFR: Deep Storage", compat_MFRDeepStorage, "This allows pipes to recoginze MFR Deep storage units correctly.")
+        compat_StorageDrawers = compat.put("Storage Drawers", compat_StorageDrawers, "This allows pipes to recognize storage drawers correctly.")
     }
 }
 


### PR DESCRIPTION
Two things I forgot/messed up in PR #6. Now the mod doesn't crash if SD is not present, and there's a config option to toggle SD compat like there is for the rest of the compats.

(In practice this doesn't really matter in the context of GTNH because Storage Drawers will likely always be there, but it makes testing the mod a little easier.)