### PR TITLE
Fix components popping off chunk border

### DIFF
--- a/src/main/scala/mrtjp/projectred/core/NewPlacementLib.scala
+++ b/src/main/scala/mrtjp/projectred/core/NewPlacementLib.scala
@@ -1,0 +1,45 @@
+package mrtjp.projectred.core
+
+import net.minecraft.init.Blocks
+import net.minecraft.world.World
+import net.minecraftforge.common.util.ForgeDirection
+
+object NewPlacementLib {
+  private val wireWhitelist = Seq(Blocks.glowstone, Blocks.piston, Blocks.sticky_piston, Blocks.piston_extension)
+
+  def canPlaceWireOnSide(w: World, x: Int, y: Int, z: Int, side: Int): Boolean = {
+    // Always allow on unloaded chunks, because we can't know what is there
+    if (!w.blockExists(x, y, z)) return true
+    val b = w.getBlock(x, y, z)
+    if (b == null) return false
+    wireWhitelist.contains(b)
+    b.isSideSolid(w, x, y, z, ForgeDirection.getOrientation(side))
+  }
+
+  private val gateWhiteList = Seq(Blocks.glass)
+
+  def canPlaceGateOnSide(w: World, x: Int, y: Int, z: Int, side: Int): Boolean = {
+    if (!w.blockExists(x, y, z)) return true
+    if (canPlaceWireOnSide(w, x, y, z, side)) return true
+
+    val b = w.getBlock(x, y, z)
+    if (b == null) return false
+    if (gateWhiteList.contains(b)) return true
+
+    false
+  }
+
+  def canPlaceTorchOnBlock(w: World, x: Int, y: Int, z: Int): Boolean = {
+    if (!w.blockExists(x, y, z)) return true
+    val b = w.getBlock(x, y, z)
+    if (b == null) return false
+    b.canPlaceTorchOnTop(w, x, y, z)
+  }
+
+  def canPlaceLight(w: World, x: Int, y: Int, z: Int, side: Int): Boolean = {
+    if (canPlaceWireOnSide(w, x, y, z, side)) return true
+    if (side == 1 && canPlaceTorchOnBlock(w, x, y, z)) return true
+
+    false
+  }
+}

--- a/src/main/scala/mrtjp/projectred/expansion/TileSolarPanel.scala
+++ b/src/main/scala/mrtjp/projectred/expansion/TileSolarPanel.scala
@@ -13,10 +13,9 @@ import codechicken.microblock.FaceMicroClass
 import codechicken.multipart.{MultiPartRegistry, TItemMultiPart, TMultiPart}
 import cpw.mods.fml.relauncher.{Side, SideOnly}
 import mrtjp.core.item.{ItemCore, TItemGlassSound}
-import mrtjp.core.world.PlacementLib
 import mrtjp.projectred.ProjectRedExpansion
 import mrtjp.projectred.api.IConnectable
-import mrtjp.projectred.core.{ILowLoadMachine, ILowLoadPowerLine, PowerConductor}
+import mrtjp.projectred.core.{ILowLoadMachine, ILowLoadPowerLine, NewPlacementLib, PowerConductor}
 import net.minecraft.client.renderer.texture.IIconRegister
 import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.item.ItemStack
@@ -130,7 +129,7 @@ class ItemSolarPanel extends ItemCore("projectred.expansion.solar_panel") with T
     override def newPart(item:ItemStack, player:EntityPlayer, world:World, pos:BlockCoord, side:Int, vhit:Vector3):TMultiPart =
     {
         val onPos = pos.copy.offset(side^1)
-        if (!PlacementLib.canPlaceGateOnSide(world, onPos.x, onPos.y, onPos.z, side)) return null
+        if (!NewPlacementLib.canPlaceGateOnSide(world, onPos.x, onPos.y, onPos.z, side)) return null
 
         val solar = MultiPartRegistry.createPart("pr_solar", false).asInstanceOf[SolarPanelPart]
         if (solar != null) solar.preparePlacement(player, pos, side, item.getItemDamage)

--- a/src/main/scala/mrtjp/projectred/expansion/partabstracts.scala
+++ b/src/main/scala/mrtjp/projectred/expansion/partabstracts.scala
@@ -8,9 +8,8 @@ package mrtjp.projectred.expansion
 import codechicken.lib.data.{MCDataInput, MCDataOutput}
 import codechicken.lib.vec.{BlockCoord, Rotation, Vector3}
 import codechicken.multipart._
-import mrtjp.core.world.PlacementLib
 import mrtjp.projectred.api.{IConnectable, IScrewdriver}
-import mrtjp.projectred.core.{TFacePowerPart, TFaceConnectable, TSwitchPacket}
+import mrtjp.projectred.core.{NewPlacementLib, TFaceConnectable, TFacePowerPart, TSwitchPacket}
 import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.item.ItemStack
 import net.minecraft.nbt.NBTTagCompound
@@ -102,7 +101,7 @@ trait TFaceElectricalDevice extends TMultiPart with TCuboidPart with TNormalOccl
     def canStay =
     {
         val pos = new BlockCoord(tile).offset(side)
-        PlacementLib.canPlaceGateOnSide(world, pos.x, pos.y, pos.z, side^1)
+        NewPlacementLib.canPlaceGateOnSide(world, pos.x, pos.y, pos.z, side^1)
     }
 
     def dropIfCantStay() =

--- a/src/main/scala/mrtjp/projectred/illumination/lightpart.scala
+++ b/src/main/scala/mrtjp/projectred/illumination/lightpart.scala
@@ -10,9 +10,9 @@ import codechicken.multipart._
 import cpw.mods.fml.relauncher.{Side, SideOnly}
 import mrtjp.core.color.Colors_old
 import mrtjp.core.vec.InvertX
-import mrtjp.core.world.{PlacementLib, WorldLib}
+import mrtjp.core.world.WorldLib
 import mrtjp.projectred.ProjectRedIllumination
-import mrtjp.projectred.core.RenderHalo
+import mrtjp.projectred.core.{NewPlacementLib, RenderHalo}
 import mrtjp.projectred.core.libmc.PRLib
 import net.minecraft.client.renderer.texture.IIconRegister
 import net.minecraft.entity.player.EntityPlayer
@@ -182,7 +182,7 @@ object BaseLightPart
 {
     def canPlaceLight(w:World, x:Int, y:Int, z:Int, side:Int):Boolean =
     {
-        if (PlacementLib.canPlaceLight(w, x, y, z, side)) return true
+        if (NewPlacementLib.canPlaceLight(w, x, y, z, side)) return true
 
         val part = PRLib.getMultiPart(w, x, y, z, side)
         if (part.isInstanceOf[HollowMicroblock]) return true

--- a/src/main/scala/mrtjp/projectred/integration/gatepart.scala
+++ b/src/main/scala/mrtjp/projectred/integration/gatepart.scala
@@ -12,9 +12,8 @@ import codechicken.lib.vec._
 import codechicken.microblock.FaceMicroClass
 import codechicken.multipart._
 import cpw.mods.fml.relauncher.{Side, SideOnly}
-import mrtjp.core.world.PlacementLib
 import mrtjp.projectred.api.{IConnectable, IScrewdriver}
-import mrtjp.projectred.core.{Configurator, TFaceConnectable, TSwitchPacket}
+import mrtjp.projectred.core.{Configurator, NewPlacementLib, TFaceConnectable, TSwitchPacket}
 import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.item.ItemStack
 import net.minecraft.nbt.NBTTagCompound
@@ -174,7 +173,7 @@ abstract class GatePart extends TMultiPart with TCuboidPart with TNormalOcclusio
     def canStay =
     {
         val pos = new BlockCoord(tile).offset(side)
-        PlacementLib.canPlaceGateOnSide(world, pos.x, pos.y, pos.z, side^1)
+        NewPlacementLib.canPlaceGateOnSide(world, pos.x, pos.y, pos.z, side^1)
     }
 
     def dropIfCantStay() =

--- a/src/main/scala/mrtjp/projectred/integration/items.scala
+++ b/src/main/scala/mrtjp/projectred/integration/items.scala
@@ -6,14 +6,13 @@
 package mrtjp.projectred.integration
 
 import java.util.{List => JList}
-
 import codechicken.lib.render.{CCRenderState, TextureUtils}
 import codechicken.lib.vec.{BlockCoord, Scale, Translation, Vector3}
 import codechicken.multipart.{MultiPartRegistry, TItemMultiPart, TMultiPart}
 import cpw.mods.fml.relauncher.{Side, SideOnly}
 import mrtjp.core.item.{ItemCore, ItemDefinition, TItemGlassSound}
-import mrtjp.core.world.PlacementLib
 import mrtjp.projectred.ProjectRedIntegration
+import mrtjp.projectred.core.NewPlacementLib
 import net.minecraft.client.renderer.texture.IIconRegister
 import net.minecraft.creativetab.CreativeTabs
 import net.minecraft.entity.player.EntityPlayer
@@ -32,7 +31,7 @@ class ItemPartGate extends ItemCore("projectred.integration.gate") with TItemMul
     def newPart(item:ItemStack, player:EntityPlayer, world:World, pos:BlockCoord, side:Int, vhit:Vector3):TMultiPart =
     {
         val onPos = pos.copy.offset(side^1)
-        if (!PlacementLib.canPlaceGateOnSide(world, onPos.x, onPos.y, onPos.z, side)) return null
+        if (!NewPlacementLib.canPlaceGateOnSide(world, onPos.x, onPos.y, onPos.z, side)) return null
 
         val gtype = GateDefinition(item.getItemDamage)
         if (!gtype.implemented) return null

--- a/src/main/scala/mrtjp/projectred/transmission/items.scala
+++ b/src/main/scala/mrtjp/projectred/transmission/items.scala
@@ -1,13 +1,12 @@
 package mrtjp.projectred.transmission
 
 import java.util.{List => JList}
-
 import codechicken.lib.vec._
 import codechicken.multipart.{MultiPartRegistry, TItemMultiPart}
 import cpw.mods.fml.relauncher.{Side, SideOnly}
 import mrtjp.core.item.{ItemCore, TItemGlassSound}
-import mrtjp.core.world.PlacementLib
 import mrtjp.projectred.ProjectRedTransmission
+import mrtjp.projectred.core.NewPlacementLib
 import net.minecraft.client.renderer.texture.IIconRegister
 import net.minecraft.creativetab.CreativeTabs
 import net.minecraft.entity.player.EntityPlayer
@@ -30,7 +29,7 @@ class ItemPartWire extends ItemWireCommon("projectred.transmission.wire")
     def newPart(item:ItemStack, player:EntityPlayer, world:World, pos:BlockCoord, side:Int, vhit:Vector3) =
     {
         val onPos = pos.copy.offset(side^1)
-        if (!PlacementLib.canPlaceWireOnSide(world, onPos.x, onPos.y, onPos.z, side)) null
+        if (!NewPlacementLib.canPlaceWireOnSide(world, onPos.x, onPos.y, onPos.z, side)) null
         else
         {
             val wiredef = WireDef.values(item.getItemDamage)

--- a/src/main/scala/mrtjp/projectred/transmission/wireabstracts.scala
+++ b/src/main/scala/mrtjp/projectred/transmission/wireabstracts.scala
@@ -8,7 +8,6 @@ import codechicken.microblock.handler.MicroblockProxy
 import codechicken.microblock.{ISidedHollowConnect, ItemMicroPart, MicroMaterialRegistry}
 import codechicken.multipart.{PartMap, TMultiPart, TNormalOcclusion, TileMultipart}
 import cpw.mods.fml.relauncher.{Side, SideOnly}
-import mrtjp.core.world.PlacementLib
 import mrtjp.projectred.ProjectRedCore
 import mrtjp.projectred.api.IConnectable
 import mrtjp.projectred.core._
@@ -247,7 +246,7 @@ abstract class WirePart extends TMultiPart with TWireCommons with TFaceConnectab
     override def canStay =
     {
         val pos = new BlockCoord(tile).offset(side)
-        PlacementLib.canPlaceWireOnSide(world, pos.x, pos.y, pos.z, side^1)
+        NewPlacementLib.canPlaceWireOnSide(world, pos.x, pos.y, pos.z, side^1)
     }
 
     override def getItem = getWireType.makeStack


### PR DESCRIPTION
Fixes components popping off when placed on a chunk boundary and the chunk they touch unloads.
Replaces MrTJPCore's PlacementLib usages with one put in this mod, so that we can modify how it behaves.