### PR TITLE
Add one-tick pulse mode to pulse former

### DIFF
--- a/src/main/scala/mrtjp/projectred/integration/gatepartcomb.scala
+++ b/src/main/scala/mrtjp/projectred/integration/gatepartcomb.scala
@@ -238,12 +238,16 @@ object Pulse extends ComboGateLogic
     override def outputMask(shape:Int) = 1
     override def inputMask(shape:Int) = 4
 
+//  Shape 0 is normal (two game tick) pulse, shape 1 is one game tick
+    override def cycleShape(shape: Int): Int = (shape+1)%2
+
     override def calcOutput(gate:ComboGatePart, input:Int) = 0
 
     override def onChange(gate:ComboGatePart) =
     {
         val oldInput = gate.state&0xF
         val newInput = getInput(gate, 4)
+        val pulseTickLength = if (gate.shape == 0) 2 else 1
 
         if (oldInput != newInput)
         {
@@ -252,7 +256,7 @@ object Pulse extends ComboGateLogic
             if (newInput != 0 && (gate.state&0xF0) == 0)
             {
                 gate.setState(gate.state&0xF|0x10)
-                gate.scheduleTick(2)
+                gate.scheduleTick(pulseTickLength)
                 gate.onOutputChange(1)
             }
         }

--- a/src/main/scala/mrtjp/projectred/integration/gaterenders.scala
+++ b/src/main/scala/mrtjp/projectred/integration/gaterenders.scala
@@ -474,29 +474,45 @@ class RenderMultiplexer extends GateRenderer[ComboGatePart]
 class RenderPulse extends GateRenderer[ComboGatePart]
 {
     val wires = generateWireModels("PULSE", 3)
-    val torches = Seq(new RedstoneTorchModel(4, 9.5, 6), new RedstoneTorchModel(11, 9.5, 6),
+    val torches1 = Seq(new RedstoneTorchModel(4, 9.5, 6), new RedstoneTorchModel(11, 9.5, 6),
         new RedstoneTorchModel(8, 3.5, 8))
+    val torches2 = Seq(new RedstoneTorchModel(4, 9.5, 6), new RedstoneTorchModel(11, 9.5, 6),
+        new RedstoneTorchModel(8, 3.5, 4))
 
-    override val coreModels = wires++torches:+new BaseComponentModel
+    var shape = 0
+    override val coreModels = Seq(new BaseComponentModel)
+    override def switchModels = if (shape == 0) wires++torches1 else wires++torches2
+    override val allSwitchModels = wires++torches1++torches2
 
     override def prepareInv()
     {
+        shape = 0
         wires(0).on = true
         wires(1).on = false
         wires(2).on = false
-        torches(0).on = true
-        torches(1).on = false
-        torches(2).on = false
+        torches1(0).on = true
+        torches1(1).on = false
+        torches1(2).on = false
     }
 
     override def prepare(gate:ComboGatePart)
     {
+        shape = gate.shape
         wires(0).on = (gate.state&4) == 0
         wires(1).on = (gate.state&4) != 0
         wires(2).on = (gate.state&0x14) == 4
-        torches(0).on = wires(0).on
-        torches(1).on = wires(1).on
-        torches(2).on = (gate.state&0x10) != 0
+        if (shape == 0)
+        {
+            torches1(0).on = wires(0).on
+            torches1(1).on = wires(1).on
+            torches1(2).on = (gate.state&0x10) != 0
+        }
+        else
+        {
+            torches2(0).on = wires(0).on
+            torches2(1).on = wires(1).on
+            torches2(2).on = (gate.state&0x10) != 0
+        }
     }
 }
 


### PR DESCRIPTION
Most redstone things take two game ticks by default, but it is sometimes desirable to have a single-tick pulse.

The use case I ran into for this is taking a single stack from an inventory when told to by redstone. This should be accomplishable easily with an IV conveyor, but without this change it is quite hard to create a one-tick pulse.

https://user-images.githubusercontent.com/73182109/195933473-2d73051b-a288-4387-a4d1-db300e1295fb.mp4

