### PR TITLE
Lamp Metadata Fix (Compat with NotEnoughIds 2.0+)

### DIFF
--- a/src/main/scala/mrtjp/projectred/illumination/renders.scala
+++ b/src/main/scala/mrtjp/projectred/illumination/renders.scala
@@ -80,7 +80,7 @@ object LampTESR extends TileEntitySpecialRenderer with IItemRenderer {
     te match {
       case light: ILight if light.isOn =>
         val meta =
-          te.getWorldObj.getBlockMetadata(te.xCoord, te.yCoord, te.zCoord)
+          te.getWorldObj.getBlockMetadata(te.xCoord, te.yCoord, te.zCoord) % 16
         RenderHalo.addLight(te.xCoord, te.yCoord, te.zCoord, meta, lBounds)
       case _ =>
     }


### PR DESCRIPTION
Ensure's that block metadata is capped at 4 bits.

This is needed because ProjectRed does attempt to use metadata values greater than 15, but fails to do so because without NotEnoughIds 16-bit metadata increase, the value just gets cut off at 15 by Minecraft. ProjectRed ended up depending on this happening, so now we are just ensuring that the value gets capped within ProjectRed.