### PR TITLE
Undo config to disable entire Fabrication module

### DIFF
--- a/src/main/scala/mrtjp/projectred/ProjectRedFabrication.scala
+++ b/src/main/scala/mrtjp/projectred/ProjectRedFabrication.scala
@@ -11,7 +11,6 @@ import cpw.mods.fml.common.event.{
   FMLPostInitializationEvent,
   FMLPreInitializationEvent
 }
-import mrtjp.projectred.core.Configurator
 import mrtjp.projectred.fabrication.{
   BlockICMachine,
   FabricationProxy,
@@ -33,8 +32,6 @@ import net.minecraft.item.ItemStack
 )
 object ProjectRedFabrication {
 
-  def isEnabled = Configurator.module_Fabrication
-
   /** Blocks * */
   var icBlock: BlockICMachine = null
 
@@ -55,13 +52,11 @@ object ProjectRedFabrication {
 
   @Mod.EventHandler
   def init(event: FMLInitializationEvent) {
-    if (isEnabled)
-      FabricationProxy.init()
+    FabricationProxy.init()
   }
 
   @Mod.EventHandler
   def postInit(event: FMLPostInitializationEvent) {
-    if (isEnabled)
-      FabricationProxy.postinit()
+    FabricationProxy.postinit()
   }
 }

--- a/src/main/scala/mrtjp/projectred/core/Configurator.scala
+++ b/src/main/scala/mrtjp/projectred/core/Configurator.scala
@@ -284,11 +284,6 @@ object Configurator extends ModConfig("ProjRed|Core") {
       module_Exploration,
       "Enable Exploration Module."
     )
-    module_Fabrication = modules.put(
-      "Fabrication Module",
-      module_Fabrication,
-      "Enable Fabrication Module."
-    )
 
   }
 }


### PR DESCRIPTION
When disabled it causes creative menu to crash as it registers an empty Creative tab with a null item throwing NPEs.

As I'm unable to prevent it from generating tabs with the way it has been implemented here using Scala so it is better to disable that feature.

Related to my previous PR: https://github.com/GTNewHorizons/ProjectRed/pull/39