### PR TITLE
Issue 19357. Fix integration PR and drawers

### DIFF
--- a/src/main/scala/mrtjp/projectred/transportation/ChipExtractor.scala
+++ b/src/main/scala/mrtjp/projectred/transportation/ChipExtractor.scala
@@ -30,7 +30,11 @@ class ChipExtractor extends RoutingChip with TChipFilter with TChipOrientation {
       val stackKey = k
       val stackSize = v
 
-      if (stackKey != null && filt.hasItem(stackKey) != filterExclude) {
+      if (
+        stackKey != null &&
+        stackSize != 0 &&
+        filt.hasItem(stackKey) != filterExclude
+      ) {
         var exclusions = BitSet.empty
         var s = routeLayer.getLogisticPath(stackKey, exclusions, true)
         if (s != null) {


### PR DESCRIPTION
closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19357

### Problem
When 2x2 or 1x2 drawer is locked extractor chip extract items only from first slot, it's occurs because ChipExtractor code [consistently iterate](https://github.com/GTNewHorizons/ProjectRed/blob/b36be573e90e8f4fb46b6cba8885274518cea290/src/main/scala/mrtjp/projectred/transportation/ChipExtractor.scala#L28-L29) via every drawer slot and if any slot is locked and has no items ChipExtractor [finish its function](https://github.com/GTNewHorizons/ProjectRed/blob/b36be573e90e8f4fb46b6cba8885274518cea290/src/main/scala/mrtjp/projectred/transportation/ChipExtractor.scala#L43) ignoring items in other drawer slots

### Fix
While iterating via every drawer slot ChipExtractor should ignore empty lock slots for the next reason
1. bug fix
2. optimization. If slot is empty there is no reason to call func [routeLayer.getLogisticPath(stackKey, exclusions, true)](https://github.com/GTNewHorizons/ProjectRed/blob/b36be573e90e8f4fb46b6cba8885274518cea290/src/main/scala/mrtjp/projectred/transportation/ChipExtractor.scala#L35)