### PR TITLE
Improve collision boxes for wires

### DIFF
--- a/src/main/scala/mrtjp/projectred/transmission/RenderWire.scala
+++ b/src/main/scala/mrtjp/projectred/transmission/RenderWire.scala
@@ -17,7 +17,7 @@ object RenderWire {
   /** Array of all built models. Generated on demand.
     */
   val wireModels = new Array[CCModel](3 * 6 * 256)
-  val invModels = new Array[CCModel](3)
+  val inventoryModels = new Array[CCModel](3)
 
   /** Returns a tightly packed unique index for the specific model represented
     * by this wire. The mask is split into 3 sections the combination of
@@ -54,10 +54,10 @@ object RenderWire {
     }
     m
   }
-  def getOrGenerateInvModel(thickness: Int) = {
-    var m = invModels(thickness)
-    if (m == null) invModels(thickness) = {
-      m = WireModelGen.getThreadLocal().generateInvModel(thickness); m
+  def getOrGenerateInventoryModel(thickness: Int) = {
+    var m = inventoryModels(thickness)
+    if (m == null) inventoryModels(thickness) = {
+      m = WireModelGen.getThreadLocal().generateInventoryModel(thickness); m
     }
     m
   }
@@ -70,8 +70,8 @@ object RenderWire {
     )
   }
 
-  def renderInv(thickness: Int, hue: Int, ops: IVertexOperation*) {
-    getOrGenerateInvModel(thickness).render(
+  def renderInventoryModel(thickness: Int, hue: Int, ops: IVertexOperation*) {
+    getOrGenerateInventoryModel(thickness).render(
       ops :+ ColourMultiplier.instance(hue): _*
     )
   }
@@ -164,21 +164,21 @@ class WireModelGen {
   var connCount = 0
   var model: CCModel = null
   var i = 0
-  var inv = false
+  var isInventoryModel = false
 
   private def numFaces: Int = {
-    if (inv) return 22
+    if (isInventoryModel) return 22
     val conns = if (connCount < 2) 2 else connCount
     var faces = conns * 3 + 5
     for (i <- 0 until 4) if ((mask >> i & 0x11) == 1) faces += 1
     faces
   }
 
-  def generateInvModel(thickness: Int) =
+  def generateInventoryModel(thickness: Int) =
     generateModel(RenderWire.modelKey(0, thickness, 0xf0), true)
 
-  def generateModel(key: Int, inv: Boolean): CCModel = {
-    this.inv = inv
+  def generateModel(key: Int, isInventoryModel: Boolean): CCModel = {
+    this.isInventoryModel = isInventoryModel
     side = (key >> 8) % 6
     tw = (key >> 8) / 6 + 1
     w = tw / 16d
@@ -231,7 +231,7 @@ class WireModelGen {
         val uvt = new UVTranslation(16, 0)
         for (vert <- verts) vert.apply(uvt)
       }
-    if (inv) verts = withBottom(verts, 0, 4)
+    if (isInventoryModel) verts = withBottom(verts, 0, 4)
 
     i = addVerts(model, verts, i)
   }
@@ -240,7 +240,7 @@ class WireModelGen {
     val stype = (mask >> r) & 0x11
 
     val verts =
-      if (inv) generateSideInv(r)
+      if (isInventoryModel) generateSideInventoryModel(r)
       else
         connCount match {
           case 0 => if (r % 2 == 1) generateStub(r) else generateFlat(r)
@@ -254,7 +254,7 @@ class WireModelGen {
     i = addVerts(model, verts, i)
   }
 
-  private def generateSideInv(r: Int) = withBottom(generateStraight(r), 4, 4)
+  private def generateSideInventoryModel(r: Int) = withBottom(generateStraight(r), 4, 4)
 
   private def generateStraight(r: Int) = {
     val verts = generateExtension(8)

--- a/src/main/scala/mrtjp/projectred/transmission/RenderWire.scala
+++ b/src/main/scala/mrtjp/projectred/transmission/RenderWire.scala
@@ -254,7 +254,8 @@ class WireModelGen {
     i = addVerts(model, verts, i)
   }
 
-  private def generateSideInventoryModel(r: Int) = withBottom(generateStraight(r), 4, 4)
+  private def generateSideInventoryModel(r: Int) =
+    withBottom(generateStraight(r), 4, 4)
 
   private def generateStraight(r: Int) = {
     val verts = generateExtension(8)

--- a/src/main/scala/mrtjp/projectred/transmission/renders.scala
+++ b/src/main/scala/mrtjp/projectred/transmission/renders.scala
@@ -73,7 +73,7 @@ object WireItemRenderer extends TWireItemRenderCommon {
       renderHue: Int,
       ops: IVertexOperation*
   ) {
-    RenderWire.renderInv(thickness, renderHue, ops: _*)
+    RenderWire.renderInventoryModel(thickness, renderHue, ops: _*)
   }
 }
 

--- a/src/main/scala/mrtjp/projectred/transmission/wireabstracts.scala
+++ b/src/main/scala/mrtjp/projectred/transmission/wireabstracts.scala
@@ -261,9 +261,9 @@ abstract class WirePart
     val b = Seq.newBuilder[Cuboid6]
 
     // Include side collision boxes if connected.
-    for (connection <- 0 until 4)
-      if (maskConnects(connection))
-        b += WireBoxes.sBounds(getThickness)(side)(connection)
+    for (rotation <- 0 until 4)
+      if (maskConnects(rotation))
+        b += WireBoxes.sBounds(getThickness)(side)(rotation)
 
     // Include center collision box.
     b += WireBoxes.sBounds(getThickness)(side)(4)

--- a/src/main/scala/mrtjp/projectred/transmission/wireabstracts.scala
+++ b/src/main/scala/mrtjp/projectred/transmission/wireabstracts.scala
@@ -257,9 +257,22 @@ abstract class WirePart
 
   override def getStrength(hit: MovingObjectPosition, player: EntityPlayer) = 4
 
-  override def getSubParts = Seq(
-    new IndexedCuboid6(0, WireBoxes.sBounds(getThickness)(side))
-  )
+  override def getCollisionBoxes = {
+    val b = Seq.newBuilder[Cuboid6]
+
+    // Include side collision boxes if connected.
+    for (connection <- 0 until 4)
+      if (maskConnects(connection))
+        b += WireBoxes.sBounds(getThickness)(side)(connection)
+
+    // Include center collision box.
+    b += WireBoxes.sBounds(getThickness)(side)(4)
+
+    b.result()
+  }
+
+  override def getSubParts =
+    getCollisionBoxes.map(that => new IndexedCuboid6(0, that))
 
   override def getOcclusionBoxes = Seq(WireBoxes.oBounds(getThickness)(side))
 
@@ -472,18 +485,34 @@ abstract class FramedWirePart
 }
 
 object WireBoxes {
-  var sBounds = Array.ofDim[Cuboid6](3, 6)
+
+  /** Wire collision boxes for each thickness, side and rotation. */
+  var sBounds = Array.ofDim[Cuboid6](3, 6, 5)
   var oBounds = Array.ofDim[Cuboid6](3, 6)
 
-  for (t <- 0 until 3) {
-    val selection = new Cuboid6(0, 0, 0, 1, (t + 2) / 16d, 1).expand(-0.005)
+  for (thickness <- 0 until 3) {
+    val height = (thickness + 2.00) / 16.00
+    val centerSelection = new Cuboid6(0.25, 0.00, 0.25, 0.75, height, 0.75)
+    val sideSelection = new Cuboid6(0.25, 0.00, 0.75, 0.75, height, 1.00)
+
+    for (side <- 0 until 6) {
+      for (rotation <- 0 until 4) {
+        sBounds(thickness)(side)(rotation) = sideSelection
+          .copy()
+          .apply(Rotation.sideOrientation(side, rotation).at(Vector3.center))
+      }
+      sBounds(thickness)(side)(4) = centerSelection
+        .copy()
+        .apply(Rotation.sideOrientation(side, 0).at(Vector3.center))
+    }
+  }
+
+  for (thickness <- 0 until 3) {
     val occlusion =
-      new Cuboid6(2 / 8d, 0, 2 / 8d, 6 / 8d, (t + 2) / 16d, 6 / 8d)
-    for (s <- 0 until 6) {
-      sBounds(t)(s) =
-        selection.copy.apply(Rotation.sideRotations(s).at(Vector3.center))
-      oBounds(t)(s) =
-        occlusion.copy.apply(Rotation.sideRotations(s).at(Vector3.center))
+      new Cuboid6(2 / 8d, 0, 2 / 8d, 6 / 8d, (thickness + 2) / 16d, 6 / 8d)
+    for (side <- 0 until 6) {
+      oBounds(thickness)(side) =
+        occlusion.copy.apply(Rotation.sideRotations(side).at(Vector3.center))
     }
   }
 


### PR DESCRIPTION
Now we can finally see what is behind those damn wires! Closes [Shrink the hitbox of red alloy wires #17558](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17558).

https://github.com/user-attachments/assets/2e688f43-0064-4ec8-a950-6dcdc2910481

