### PR TITLE
Add missing equals sign to `en_US.lang`

### DIFF
--- a/src/main/resources/assets/projectred/lang/en_US.lang
+++ b/src/main/resources/assets/projectred/lang/en_US.lang
@@ -464,7 +464,7 @@ item.projectred.illumination.cagelamp2.inv|13.name=Inverted Green Cage Lamp
 item.projectred.illumination.cagelamp2.inv|14.name=Inverted Red Cage Lamp
 item.projectred.illumination.cagelamp2.inv|15.name=Inverted Black Cage Lamp
 tile.projectred.illumination.airousLight.name=Airous Light
-tile.projectred.illumination.airousLight|0.nameAirous Light
+tile.projectred.illumination.airousLight|0.name=Airous Light
 
 
 


### PR DESCRIPTION
Downloaded the latest nightly - apparently some new lang-file mistakes have appeared since 2.6.1.