### PR TITLE
fix java.lang.VerifyError in tileicprinter

### DIFF
--- a/src/main/scala/mrtjp/projectred/fabrication/tileicprinter.scala
+++ b/src/main/scala/mrtjp/projectred/fabrication/tileicprinter.scala
@@ -411,8 +411,7 @@ object TileICPrinter {
         .getRecipeList
         .asInstanceOf[JList[IRecipe]]
         .iterator()
-    while (recipes.hasNext) {
-      val r = recipes.next()
+    for (r <- recipes)
       try {
         val out = ItemKey.get(r.getRecipeOutput)
         if (out == key) {
@@ -456,7 +455,6 @@ object TileICPrinter {
         case e: Exception =>
           log.error(s"Some mod messed up. The recipe $r has a null output.")
       }
-    }
     gRec += key -> Seq.empty
   }
 


### PR DESCRIPTION
```
java.lang.VerifyError: Bad local variable type
Exception Details:
  Location:
    mrtjp/projectred/fabrication/TileICPrinter$.cacheRecipe(Lmrtjp/core/item/ItemKey;)V @61: aload
  Reason:
    Type top (current frame, locals[4]) is not assignable to reference type
```