### PR TITLE
[Memory-opti:fix leak] fix 2 world server memory leak caused by reusableRun object pools

### DIFF
--- a/src/main/scala/mrtjp/projectred/ProjectRedTransmission.scala
+++ b/src/main/scala/mrtjp/projectred/ProjectRedTransmission.scala
@@ -3,6 +3,7 @@ package mrtjp.projectred
 import cpw.mods.fml.common.Mod
 import cpw.mods.fml.common.event._
 import mrtjp.projectred.api.ProjectRedAPI
+import mrtjp.projectred.fabrication.ICPropagator
 import mrtjp.projectred.transmission._
 import net.minecraft.creativetab.CreativeTabs
 import net.minecraft.item.ItemStack
@@ -46,7 +47,8 @@ object ProjectRedTransmission {
   }
 
   @Mod.EventHandler
-  def serverStopping(event: FMLServerAboutToStartEvent) {
+  def serverStopping(event: FMLServerStoppedEvent) {
     WirePropagator.reset()
+    ICPropagator.reset()
   }
 }

--- a/src/main/scala/mrtjp/projectred/fabrication/wirepropagation.scala
+++ b/src/main/scala/mrtjp/projectred/fabrication/wirepropagation.scala
@@ -20,6 +20,14 @@ object ICPropagator {
   var currentRun: ICPropagationRun = null
   var finishing: ICPropagationRun = null
 
+  def reset() {
+    redwiresProvidePower = true
+    redwiresConnectable = true
+    reusableRuns.clear()
+    currentRun = null
+    finishing = null
+  }
+
   val notApart = new CircuitPart {
     override def getPartType = null
     @SideOnly(Side.CLIENT)
@@ -72,11 +80,13 @@ class ICPropagationRun {
   var analogDrops = Seq.newBuilder[ICPropagation]
 
   def clear() {
-    partChanges.clear()
-    neighborChanges.clear()
+    world = null
+    parent = null
+    lastCaller = null
     count = 0
     recalcs = 0
-    lastCaller = null
+    partChanges.clear()
+    neighborChanges.clear()
     ICPropagator.reusableRuns.add(this)
   }
 

--- a/src/main/scala/mrtjp/projectred/transmission/propagation.scala
+++ b/src/main/scala/mrtjp/projectred/transmission/propagation.scala
@@ -13,6 +13,7 @@ import net.minecraft.world.World
 import scala.collection.immutable.HashSet
 
 object WirePropagator {
+
   private val wiresProvidePower = {
     try {
       val c = classOf[BlockRedstoneWire].getDeclaredFields.apply(0)
@@ -20,6 +21,7 @@ object WirePropagator {
       c
     } catch { case e: Exception => throw new RuntimeException(e) }
   }
+
   def setDustProvidePower(b: Boolean) {
     try { wiresProvidePower.setBoolean(Blocks.redstone_wire, b) }
     catch { case t: Throwable => }
@@ -28,6 +30,7 @@ object WirePropagator {
   private val rwConnectable = {
     val b = new ThreadLocal[Boolean]; b.set(true); b
   }
+
   def redwiresConnectable = rwConnectable.get
   def setRedwiresConnectable(b: Boolean) { rwConnectable.set(b) }
 
@@ -37,6 +40,9 @@ object WirePropagator {
     setDustProvidePower(true)
     setRedwiresConnectable(true)
     redwiresProvidePower = true
+    reusableRuns.clear()
+    currentRun = null
+    finishing = null
   }
 
   val reusableRuns = new JStack[PropagationRun]()
@@ -95,9 +101,11 @@ class PropagationRun {
   def clear() {
     partChanges.clear()
     neighborChanges.clear()
+    world = null
+    parent = null
+    lastCaller = null
     count = 0
     recalcs = 0
-    lastCaller = null
     WirePropagator.reusableRuns.add(this)
   }
 


### PR DESCRIPTION
<img width="670" height="225" alt="image" src="https://github.com/user-attachments/assets/a2f5c329-6542-467e-bfe2-898c53548006" />
<img width="484" height="126" alt="image" src="https://github.com/user-attachments/assets/26db13bb-5d0b-47f6-b0ed-8ca1d932fd4a" />
