### PR TITLE
Make model don't use too much memory

### DIFF
--- a/src/main/scala/mrtjp/projectred/integration/components.scala
+++ b/src/main/scala/mrtjp/projectred/integration/components.scala
@@ -241,9 +241,11 @@ abstract class ComponentModel {
 
 abstract class SingleComponentModel(m: CCModel, pos: Vector3 = Vector3.zero)
     extends ComponentModel {
-  def models(orient: Int) = {
+  val models = {
+    val xs = new Array[CCModel](48)
     val t = pos.copy.multiply(1 / 16d).translation
-    bakeCopy(m.copy.apply(t), orient)
+    for (i <- 0 until 48) xs(i) = bakeCopy(m.copy.apply(t), i)
+    xs
   }
 
   def getUVT: UVTransformation

--- a/src/main/scala/mrtjp/projectred/integration/components.scala
+++ b/src/main/scala/mrtjp/projectred/integration/components.scala
@@ -254,7 +254,7 @@ abstract class ComponentModel {
 
 abstract class SingleComponentModel(m: CCModel, pos: Vector3 = Vector3.zero)
     extends ComponentModel {
-  // instead of creating 48 models, only make 2 (original + vertex flipped)
+  // instead of creating 48 models, only make 2 (original + flipped orientation)
   val model_pair = {
     val t = pos.copy.multiply(1 / 16d).translation
     bakeDynamic(m.copy.apply(t))
@@ -265,7 +265,7 @@ abstract class SingleComponentModel(m: CCModel, pos: Vector3 = Vector3.zero)
   def getUVT: UVTransformation
 
   override def renderModel(t: Transformation, orient: Int) {
-    model_pair(if (orient < 24) 0 else 1).render(new TransformationList(extraTransformModel(orient), t), getUVT)
+    model_pair(if (orient < 24) 0 else 1).render(new TransformationList(extraTransformModel(orient), t), getUVT, LightModel.standardLightModel)
   }
 }
 

--- a/src/main/scala/mrtjp/projectred/integration/components.scala
+++ b/src/main/scala/mrtjp/projectred/integration/components.scala
@@ -241,11 +241,9 @@ abstract class ComponentModel {
 
 abstract class SingleComponentModel(m: CCModel, pos: Vector3 = Vector3.zero)
     extends ComponentModel {
-  val models = {
-    val xs = new Array[CCModel](48)
+  def models(orient: Int) = {
     val t = pos.copy.multiply(1 / 16d).translation
-    for (i <- 0 until 48) xs(i) = bakeCopy(m.copy.apply(t), i)
-    xs
+    bakeCopy(m.copy.apply(t), orient)
   }
 
   def getUVT: UVTransformation

--- a/src/main/scala/mrtjp/projectred/integration/components.scala
+++ b/src/main/scala/mrtjp/projectred/integration/components.scala
@@ -93,6 +93,19 @@ object ComponentStore {
   var icChipIconOff: IIcon = null
   var icHousingIcon: IIcon = null
 
+  val orientPrecomputed = (0 until 48).map(orientT).toArray
+  val bundledCablePrecomputed = (0 until 48).map((orient: Int) => {
+    val side = orient % 24 >> 2
+    val r = orient & 3
+    val reflect = orient >= 24
+    val rotate = (r + WireModelGen.reorientSide(side)) % 4 >= 2
+
+    var t: Transformation = new RedundantTransformation
+    if (reflect) t = t.`with`(new Scale(-1, 0, 1))
+    if (rotate) t = t.`with`(Rotation.quarterRotations(2))
+    t
+  }).toArray
+
   def registerIcons(reg: IIconRegister) {
     val baseTex = "projectred:integration/"
     def register(path: String) = reg.registerIcon(baseTex + path)
@@ -241,17 +254,18 @@ abstract class ComponentModel {
 
 abstract class SingleComponentModel(m: CCModel, pos: Vector3 = Vector3.zero)
     extends ComponentModel {
-  val models = {
-    val xs = new Array[CCModel](48)
+  // instead of creating 48 models, only make 2 (original + vertex flipped)
+  val model_pair = {
     val t = pos.copy.multiply(1 / 16d).translation
-    for (i <- 0 until 48) xs(i) = bakeCopy(m.copy.apply(t), i)
-    xs
+    bakeDynamic(m.copy.apply(t))
   }
+
+  def extraTransformModel(orient: Int): Transformation = orientPrecomputed(orient)
 
   def getUVT: UVTransformation
 
   override def renderModel(t: Transformation, orient: Int) {
-    models(orient).render(t, getUVT)
+    model_pair(if (orient < 24) 0 else 1).render(new TransformationList(extraTransformModel(orient), t), getUVT)
   }
 }
 
@@ -608,19 +622,11 @@ abstract class BundledCableModel(
     uCenter: Double,
     vCenter: Double
 ) extends SingleComponentModel(model, pos) {
-  for (orient <- 0 until 48) {
-    val side = orient % 24 >> 2
-    val r = orient & 3
-    val reflect = orient >= 24
-    val rotate = (r + WireModelGen.reorientSide(side)) % 4 >= 2
-
-    var t: Transformation = new RedundantTransformation
-    if (reflect) t = t.`with`(new Scale(-1, 0, 1))
-    if (rotate) t = t.`with`(Rotation.quarterRotations(2))
-
-    if (!t.isInstanceOf[RedundantTransformation])
-      models(orient).apply(new UVT(t.at(new Vector3(uCenter, 0, vCenter))))
-  }
+  private val newTransforms = (0 until 48).map((orient: Int) =>{
+    val t = bundledCablePrecomputed(orient)
+    new TransformationList(super.extraTransformModel(orient), t.at(new Vector3(uCenter, 0, vCenter)))
+  })
+  override def extraTransformModel(orient: Int): Transformation = newTransforms(orient)
 }
 
 class BusXcvrCableModel

--- a/src/main/scala/mrtjp/projectred/integration/components.scala
+++ b/src/main/scala/mrtjp/projectred/integration/components.scala
@@ -257,7 +257,7 @@ abstract class ComponentModel {
 abstract class SingleComponentModel(m: CCModel, pos: Vector3 = Vector3.zero)
     extends ComponentModel {
   // instead of creating 48 models, only make 2 (original + flipped orientation)
-  val model_pair = {
+  private val modelPair = {
     val t = pos.copy.multiply(1 / 16d).translation
     bakeDynamic(m.copy.apply(t))
   }
@@ -269,7 +269,7 @@ abstract class SingleComponentModel(m: CCModel, pos: Vector3 = Vector3.zero)
   def getUVT: UVTransformation
 
   override def renderModel(t: Transformation, orient: Int) {
-    model_pair(if (orient < 24) 0 else 1).render(
+    modelPair(if (orient < 24) 0 else 1).render(
       new TransformationList(extraTransformModel(orient), t),
       getUVT,
       LightModel.standardLightModel

--- a/src/main/scala/mrtjp/projectred/integration/components.scala
+++ b/src/main/scala/mrtjp/projectred/integration/components.scala
@@ -94,17 +94,19 @@ object ComponentStore {
   var icHousingIcon: IIcon = null
 
   val orientPrecomputed = (0 until 48).map(orientT).toArray
-  val bundledCablePrecomputed = (0 until 48).map((orient: Int) => {
-    val side = orient % 24 >> 2
-    val r = orient & 3
-    val reflect = orient >= 24
-    val rotate = (r + WireModelGen.reorientSide(side)) % 4 >= 2
+  val bundledCablePrecomputed = (0 until 48)
+    .map((orient: Int) => {
+      val side = orient % 24 >> 2
+      val r = orient & 3
+      val reflect = orient >= 24
+      val rotate = (r + WireModelGen.reorientSide(side)) % 4 >= 2
 
-    var t: Transformation = new RedundantTransformation
-    if (reflect) t = t.`with`(new Scale(-1, 0, 1))
-    if (rotate) t = t.`with`(Rotation.quarterRotations(2))
-    t
-  }).toArray
+      var t: Transformation = new RedundantTransformation
+      if (reflect) t = t.`with`(new Scale(-1, 0, 1))
+      if (rotate) t = t.`with`(Rotation.quarterRotations(2))
+      t
+    })
+    .toArray
 
   def registerIcons(reg: IIconRegister) {
     val baseTex = "projectred:integration/"
@@ -260,12 +262,18 @@ abstract class SingleComponentModel(m: CCModel, pos: Vector3 = Vector3.zero)
     bakeDynamic(m.copy.apply(t))
   }
 
-  def extraTransformModel(orient: Int): Transformation = orientPrecomputed(orient)
+  def extraTransformModel(orient: Int): Transformation = orientPrecomputed(
+    orient
+  )
 
   def getUVT: UVTransformation
 
   override def renderModel(t: Transformation, orient: Int) {
-    model_pair(if (orient < 24) 0 else 1).render(new TransformationList(extraTransformModel(orient), t), getUVT, LightModel.standardLightModel)
+    model_pair(if (orient < 24) 0 else 1).render(
+      new TransformationList(extraTransformModel(orient), t),
+      getUVT,
+      LightModel.standardLightModel
+    )
   }
 }
 
@@ -622,11 +630,16 @@ abstract class BundledCableModel(
     uCenter: Double,
     vCenter: Double
 ) extends SingleComponentModel(model, pos) {
-  private val newTransforms = (0 until 48).map((orient: Int) =>{
+  private val newTransforms = (0 until 48).map((orient: Int) => {
     val t = bundledCablePrecomputed(orient)
-    new TransformationList(super.extraTransformModel(orient), t.at(new Vector3(uCenter, 0, vCenter)))
+    new TransformationList(
+      super.extraTransformModel(orient),
+      t.at(new Vector3(uCenter, 0, vCenter))
+    )
   })
-  override def extraTransformModel(orient: Int): Transformation = newTransforms(orient)
+  override def extraTransformModel(orient: Int): Transformation = newTransforms(
+    orient
+  )
 }
 
 class BusXcvrCableModel


### PR DESCRIPTION
Improve the model rendering code so it doesn't instantiate 48 models but only 2 models. The rotation of the model is delayed and calculated together with the translation. The lighting calculation is also included.
