### PR TITLE
Optimize memory usage of model pt. 2

### DIFF
--- a/src/main/scala/mrtjp/projectred/fabrication/fmpgatepart.scala
+++ b/src/main/scala/mrtjp/projectred/fabrication/fmpgatepart.scala
@@ -287,7 +287,7 @@ class RenderCircuitGate extends GateRenderer[CircuitGatePart] {
   var name = "untitled"
 
   override val coreModels = Seq(
-    new integration.BaseComponentModel,
+    integration.BaseComponentModel.model,
     simp,
     analog,
     bundled,

--- a/src/main/scala/mrtjp/projectred/integration/components.scala
+++ b/src/main/scala/mrtjp/projectred/integration/components.scala
@@ -917,14 +917,11 @@ object CellTopWireModel {
 }
 
 class CellTopWireModel(wireTop: CCModel) extends CellWireModel {
-  val top = new Array[CCModel](24)
   var conn = 0
-
-  for (i <- 0 until 24) top(i) = bakeCopy(wireTop, i)
 
   override def renderModel(t: Transformation, orient: Int) {
     val icont = new IconTransformation(cellIcon)
-    top(orient).render(t, icont, colourMult)
+    wireTop.render(new TransformationList(orientPrecomputed(orient), t), icont, colourMult)
     import mrtjp.projectred.integration.CellTopWireModel._
     if ((conn & 2) == 0) right(orient).render(t, icont, colourMult)
     if ((conn & 8) == 0) left(orient).render(t, icont, colourMult)
@@ -932,12 +929,9 @@ class CellTopWireModel(wireTop: CCModel) extends CellWireModel {
 }
 
 class CellBottomWireModel(wireBottom: CCModel) extends CellWireModel {
-  val bottom = new Array[CCModel](24)
-
-  for (i <- 0 until 24) bottom(i) = bakeCopy(wireBottom, i)
 
   override def renderModel(t: Transformation, orient: Int) {
-    bottom(orient).render(t, new IconTransformation(cellIcon), colourMult)
+    wireBottom.render(new TransformationList(orientPrecomputed(orient), t), new IconTransformation(cellIcon), colourMult)
   }
 }
 

--- a/src/main/scala/mrtjp/projectred/integration/components.scala
+++ b/src/main/scala/mrtjp/projectred/integration/components.scala
@@ -284,11 +284,10 @@ abstract class SingleComponentModel(m: CCModel, pos: Vector3 = Vector3.zero)
 abstract class MultiComponentModel(m: Seq[CCModel], pos: Vector3 = Vector3.zero)
     extends ComponentModel {
   val models = {
-    val xs = Array.ofDim[CCModel](m.length, 48)
+    val xs = Array.ofDim[CCModel](m.length, 2)
     val t = pos.copy.multiply(1 / 16d).translation
     for (i <- m.indices)
-      for (j <- 0 until 48)
-        xs(i)(j) = bakeCopy(m.apply(i).copy.apply(t), j)
+      xs(i) = bakeDynamic(m.apply(i).copy.apply(t))
     xs
   }
 
@@ -297,7 +296,8 @@ abstract class MultiComponentModel(m: Seq[CCModel], pos: Vector3 = Vector3.zero)
   def getUVT: UVTransformation
 
   override def renderModel(t: Transformation, orient: Int) {
-    models(state)(orient).render(t, getUVT)
+    models(state)(if (orient < 24) 0 else 1)
+      .render(new TransformationList(orientPrecomputed(orient), t), getUVT)
   }
 }
 
@@ -781,7 +781,6 @@ class SigLightPanelModel(pos: Vector3, rotY: Boolean) extends ComponentModel {
 }
 
 class SignalBarModel(x: Double, z: Double) extends ComponentModel {
-  val models = new Array[CCModel](48)
   val bars = new Array[CCModel](16)
   val barsInv = new Array[CCModel](16)
   var barsBg: CCModel = null
@@ -792,7 +791,7 @@ class SignalBarModel(x: Double, z: Double) extends ComponentModel {
   var signal = 0
   var inverted = false
 
-  {
+  val model = {
     for (i <- 1 to 16) {
       val bar = CCModel.quadModel(4)
       val y = 12 / 32d + 0.0001d
@@ -821,15 +820,17 @@ class SignalBarModel(x: Double, z: Double) extends ComponentModel {
     barsBg = bars(15).copy.apply(t)
     barsBgInv = barsInv(15).copy.apply(t)
 
-    val base = signalPanel.copy.apply(pos.translation())
-    for (i <- 0 until 48) models(i) = bakeCopy(base, i)
+    signalPanel.copy.apply(pos.translation())
   }
 
   def renderModel(t: Transformation, orient: Int) {
     val iconT = new IconTransformation(busConvIcon)
-    models(orient % 24).render(t, iconT)
+    model.render(
+      new TransformationList(orientPrecomputed(orient % 24), t),
+      iconT
+    )
     val position = new TransformationList(pos.translation)
-      .`with`(orientT(orient % 24))
+      .`with`(orientPrecomputed(orient % 24))
       .`with`(t)
     (if (inverted) barsBgInv else barsBg).render(
       position,

--- a/src/main/scala/mrtjp/projectred/integration/components.scala
+++ b/src/main/scala/mrtjp/projectred/integration/components.scala
@@ -323,6 +323,10 @@ class BaseComponentModel extends SingleComponentModel(base) {
   override def getUVT = new IconTransformation(baseIcon)
 }
 
+object BaseComponentModel {
+  val model = new BaseComponentModel
+}
+
 trait TWireModel extends ComponentModel {
   var on = false
   var disabled = false

--- a/src/main/scala/mrtjp/projectred/integration/components.scala
+++ b/src/main/scala/mrtjp/projectred/integration/components.scala
@@ -267,7 +267,8 @@ abstract class SingleComponentModel(m: CCModel, pos: Vector3 = Vector3.zero)
     orient
   )
 
-  def extraTransformModelUV(orient: Int): UVTransformation = redundantUVTransformation
+  def extraTransformModelUV(orient: Int): UVTransformation =
+    redundantUVTransformation
 
   def getUVT: UVTransformation
 
@@ -637,9 +638,10 @@ abstract class BundledCableModel(
     val t = bundledCablePrecomputed(orient)
     new UVT(t.at(new Vector3(uCenter, 0, vCenter)))
   })
-  override def extraTransformModelUV(orient: Int): UVTransformation = newTransforms(
-    orient
-  )
+  override def extraTransformModelUV(orient: Int): UVTransformation =
+    newTransforms(
+      orient
+    )
 }
 
 class BusXcvrCableModel
@@ -744,8 +746,12 @@ class SigLightPanelModel(pos: Vector3, rotY: Boolean) extends ComponentModel {
 
   override def renderModel(t: Transformation, orient: Int) {
     val icont = new IconTransformation(busXcvrIcon)
-    (if (sideInd) modelsSIPair else modelsPair) (if (orient < 24) 0 else 1).render(
-      new TransformationList(orientPrecomputed(orient), t), icont, LightModel.standardLightModel)
+    (if (sideInd) modelsSIPair else modelsPair) (if (orient < 24) 0 else 1)
+      .render(
+        new TransformationList(orientPrecomputed(orient), t),
+        icont,
+        LightModel.standardLightModel
+      )
 
     val dPos = pos.copy
     if (orient >= 24) dPos.x = 1 - dPos.x
@@ -921,7 +927,11 @@ class CellTopWireModel(wireTop: CCModel) extends CellWireModel {
 
   override def renderModel(t: Transformation, orient: Int) {
     val icont = new IconTransformation(cellIcon)
-    wireTop.render(new TransformationList(orientPrecomputed(orient), t), icont, colourMult)
+    wireTop.render(
+      new TransformationList(orientPrecomputed(orient), t),
+      icont,
+      colourMult
+    )
     import mrtjp.projectred.integration.CellTopWireModel._
     if ((conn & 2) == 0) right(orient).render(t, icont, colourMult)
     if ((conn & 8) == 0) left(orient).render(t, icont, colourMult)
@@ -931,7 +941,11 @@ class CellTopWireModel(wireTop: CCModel) extends CellWireModel {
 class CellBottomWireModel(wireBottom: CCModel) extends CellWireModel {
 
   override def renderModel(t: Transformation, orient: Int) {
-    wireBottom.render(new TransformationList(orientPrecomputed(orient), t), new IconTransformation(cellIcon), colourMult)
+    wireBottom.render(
+      new TransformationList(orientPrecomputed(orient), t),
+      new IconTransformation(cellIcon),
+      colourMult
+    )
   }
 }
 

--- a/src/main/scala/mrtjp/projectred/integration/components.scala
+++ b/src/main/scala/mrtjp/projectred/integration/components.scala
@@ -107,6 +107,7 @@ object ComponentStore {
       t
     })
     .toArray
+  val redundantUVTransformation = new UVTransformationList()
 
   def registerIcons(reg: IIconRegister) {
     val baseTex = "projectred:integration/"
@@ -266,12 +267,14 @@ abstract class SingleComponentModel(m: CCModel, pos: Vector3 = Vector3.zero)
     orient
   )
 
+  def extraTransformModelUV(orient: Int): UVTransformation = redundantUVTransformation
+
   def getUVT: UVTransformation
 
   override def renderModel(t: Transformation, orient: Int) {
     modelPair(if (orient < 24) 0 else 1).render(
       new TransformationList(extraTransformModel(orient), t),
-      getUVT,
+      new UVTransformationList(extraTransformModelUV(orient), getUVT),
       LightModel.standardLightModel
     )
   }
@@ -632,12 +635,9 @@ abstract class BundledCableModel(
 ) extends SingleComponentModel(model, pos) {
   private val newTransforms = (0 until 48).map((orient: Int) => {
     val t = bundledCablePrecomputed(orient)
-    new TransformationList(
-      super.extraTransformModel(orient),
-      t.at(new Vector3(uCenter, 0, vCenter))
-    )
+    new UVT(t.at(new Vector3(uCenter, 0, vCenter)))
   })
-  override def extraTransformModel(orient: Int): Transformation = newTransforms(
+  override def extraTransformModelUV(orient: Int): UVTransformation = newTransforms(
     orient
   )
 }
@@ -687,8 +687,8 @@ class SigLightPanelModel(pos: Vector3, rotY: Boolean) extends ComponentModel {
     this(new Vector3(x, 0, z), rotY)
 
   val displayModels = new Array[CCModel](16)
-  val models = new Array[CCModel](48)
-  val modelsSI = new Array[CCModel](48)
+  val modelsPair = new Array[CCModel](2)
+  val modelsSIPair = new Array[CCModel](2)
 
   var sideInd = true
 
@@ -733,15 +733,19 @@ class SigLightPanelModel(pos: Vector3, rotY: Boolean) extends ComponentModel {
     base.apply(pos.translation())
     baseSI.apply(pos.translation())
 
-    for (i <- 0 until 48) {
-      models(i) = bakeCopy(base, i)
-      modelsSI(i) = bakeCopy(baseSI, i)
+    val model = bakeDynamic(base)
+    val modelSI = bakeDynamic(baseSI)
+
+    for (i <- 0 until 2) {
+      modelsPair(i) = model(i)
+      modelsSIPair(i) = modelSI(i)
     }
   }
 
   override def renderModel(t: Transformation, orient: Int) {
     val icont = new IconTransformation(busXcvrIcon)
-    (if (sideInd) modelsSI else models) (orient).render(t, icont)
+    (if (sideInd) modelsSIPair else modelsPair) (if (orient < 24) 0 else 1).render(
+      new TransformationList(orientPrecomputed(orient), t), icont, LightModel.standardLightModel)
 
     val dPos = pos.copy
     if (orient >= 24) dPos.x = 1 - dPos.x

--- a/src/main/scala/mrtjp/projectred/integration/gaterenders.scala
+++ b/src/main/scala/mrtjp/projectred/integration/gaterenders.scala
@@ -157,7 +157,7 @@ class RenderOR extends GateRenderer[ComboGatePart] {
   val torches =
     Seq(new RedstoneTorchModel(8, 9, 6), new RedstoneTorchModel(8, 2.5, 8))
 
-  override val coreModels = wires ++ torches :+ new BaseComponentModel
+  override val coreModels = wires ++ torches :+ BaseComponentModel.model
 
   override def prepareInv() {
     wires(0).on = true
@@ -188,7 +188,7 @@ class RenderNOR extends GateRenderer[ComboGatePart] {
   var wires = generateWireModels("NOR", 4)
   var torch = new RedstoneTorchModel(8, 9, 6)
 
-  override val coreModels = wires :+ torch :+ new BaseComponentModel
+  override val coreModels = wires :+ torch :+ BaseComponentModel.model
 
   override def prepareInv() {
     wires(0).on = true
@@ -217,7 +217,7 @@ class RenderNOT extends GateRenderer[ComboGatePart] {
   val wires = generateWireModels("NOT", 4)
   val torch = new RedstoneTorchModel(8, 8, 6)
 
-  override val coreModels = wires :+ torch :+ new BaseComponentModel
+  override val coreModels = wires :+ torch :+ BaseComponentModel.model
 
   override def prepareInv() {
     wires(0).on = true
@@ -251,7 +251,7 @@ class RenderAND extends GateRenderer[ComboGatePart] {
     new RedstoneTorchModel(8, 2, 8)
   )
 
-  override val coreModels = wires ++ torches :+ new BaseComponentModel
+  override val coreModels = wires ++ torches :+ BaseComponentModel.model
 
   override def prepareInv() {
     wires(0).on = true
@@ -290,7 +290,7 @@ class RenderNAND extends GateRenderer[ComboGatePart] {
     new RedstoneTorchModel(8, 8, 6)
   )
 
-  override val coreModels = wires ++ torches :+ new BaseComponentModel
+  override val coreModels = wires ++ torches :+ BaseComponentModel.model
 
   override def prepareInv() {
     wires(0).on = true
@@ -327,7 +327,7 @@ class RenderXOR extends GateRenderer[ComboGatePart] {
     new RedstoneTorchModel(8, 12, 6)
   )
 
-  override val coreModels = wires ++ torches :+ new BaseComponentModel
+  override val coreModels = wires ++ torches :+ BaseComponentModel.model
 
   override def prepareInv() {
     wires(0).on = false
@@ -359,7 +359,7 @@ class RenderXNOR extends GateRenderer[ComboGatePart] {
     new RedstoneTorchModel(8, 12, 6)
   )
 
-  override val coreModels = wires ++ torches :+ new BaseComponentModel
+  override val coreModels = wires ++ torches :+ BaseComponentModel.model
 
   override def prepareInv() {
     wires(0).on = false
@@ -390,7 +390,7 @@ class RenderBuffer extends GateRenderer[ComboGatePart] {
   val torches =
     Seq(new RedstoneTorchModel(8, 3.5, 8), new RedstoneTorchModel(8, 9, 6))
 
-  override val coreModels = wires ++ torches :+ new BaseComponentModel
+  override val coreModels = wires ++ torches :+ BaseComponentModel.model
 
   override def prepareInv() {
     wires(0).on = true
@@ -424,7 +424,7 @@ class RenderMultiplexer extends GateRenderer[ComboGatePart] {
     new RedstoneTorchModel(11.5, 8, 6)
   )
 
-  override val coreModels = wires ++ torches :+ new BaseComponentModel
+  override val coreModels = wires ++ torches :+ BaseComponentModel.model
 
   override def prepareInv() {
     wires(0).on = false
@@ -467,7 +467,7 @@ class RenderPulse extends GateRenderer[ComboGatePart] {
   )
 
   var shape = 0
-  override val coreModels = Seq(new BaseComponentModel)
+  override val coreModels = Seq(BaseComponentModel.model)
   override def switchModels =
     if (shape == 0) wires ++ torches1 else wires ++ torches2
   override val allSwitchModels = wires ++ torches1 ++ torches2
@@ -516,7 +516,7 @@ class RenderRepeater extends GateRenderer[ComboGatePart] {
 
   var shape = 0
 
-  override val coreModels = wires ++ Seq(endTorch, new BaseComponentModel)
+  override val coreModels = wires ++ Seq(endTorch, BaseComponentModel.model)
 
   override def switchModels = Seq(varTorches(shape))
   override def allSwitchModels = varTorches
@@ -546,7 +546,7 @@ class RenderRandomizer extends GateRenderer[ComboGatePart] {
     new YellowChipModel(4.5, 11.5)
   )
 
-  override val coreModels = wires ++ chips :+ new BaseComponentModel
+  override val coreModels = wires ++ chips :+ BaseComponentModel.model
 
   override def prepareInv() {
     wires(0).on = false
@@ -596,7 +596,7 @@ class RenderSRLatch extends GateRenderer[SequentialGatePart] {
     Seq(new RedstoneTorchModel(9.5, 3, 6), new RedstoneTorchModel(6.5, 13, 6))
   var shape = 0
 
-  override val coreModels = Seq(new BaseComponentModel)
+  override val coreModels = Seq(BaseComponentModel.model)
   override def switchModels =
     if (shape == 0) wires1 ++ torches1 else wires2 ++ torches2
   override val allSwitchModels = wires1 ++ wires2 ++ torches1 ++ torches2
@@ -638,7 +638,7 @@ class RenderToggleLatch extends GateRenderer[SequentialGatePart] {
   val lever = new LeverModel(11, 8)
 
   override val coreModels =
-    wires ++ torches ++ Seq(lever, new BaseComponentModel)
+    wires ++ torches ++ Seq(lever, BaseComponentModel.model)
 
   override def prepareInv() {
     wires(0).on = false
@@ -667,7 +667,7 @@ class RenderTransparentLatch extends GateRenderer[ComboGatePart] {
     new RedstoneTorchModel(14, 8, 8)
   )
 
-  override val coreModels = wires ++ torches :+ new BaseComponentModel
+  override val coreModels = wires ++ torches :+ BaseComponentModel.model
 
   override def prepareInv() {
     reflect = false
@@ -703,7 +703,7 @@ class RenderLightSensor extends GateRenderer[ComboGatePart] {
   val wires = generateWireModels("LIGHTSENSOR", 1)
   val solar = new SolarModel(8, 5.5)
 
-  override val coreModels = wires ++ Seq(solar, new BaseComponentModel)
+  override val coreModels = wires ++ Seq(solar, BaseComponentModel.model)
 
   override def prepareInv() {
     wires(0).on = false
@@ -720,7 +720,7 @@ class RenderRainSensor extends GateRenderer[ComboGatePart] {
   val wires = generateWireModels("RAINSENSOR", 1)
   val sensor = new RainSensorModel(8, 6)
 
-  override val coreModels = wires ++ Seq(sensor, new BaseComponentModel)
+  override val coreModels = wires ++ Seq(sensor, BaseComponentModel.model)
 
   override def prepareInv() {
     wires(0).on = false
@@ -737,7 +737,7 @@ class RenderTimer extends GateRenderer[SequentialGatePart] {
     Seq(new RedstoneTorchModel(8, 3, 6), new RedstoneTorchModel(8, 8, 12))
   val pointer = new PointerModel(8, 8, 8)
 
-  override val coreModels = wires ++ torches :+ new BaseComponentModel
+  override val coreModels = wires ++ torches :+ BaseComponentModel.model
 
   override def prepareInv() {
     wires(0).on = false
@@ -783,7 +783,7 @@ class RenderSequencer extends GateRenderer[SequentialGatePart] {
 
   torches(0).on = true
 
-  override val coreModels = torches :+ new BaseComponentModel
+  override val coreModels = torches :+ BaseComponentModel.model
 
   override def prepare(gate: SequentialGatePart) {
     torches(1).on = (gate.state & 0x10) != 0
@@ -830,7 +830,7 @@ class RenderCounter extends GateRenderer[SequentialGatePart] {
 
   torches(0).on = true
 
-  override val coreModels = wires ++ torches :+ new BaseComponentModel
+  override val coreModels = wires ++ torches :+ BaseComponentModel.model
 
   override def prepare(gate: SequentialGatePart) {
     reflect = gate.shape == 1
@@ -877,7 +877,7 @@ class RenderStateCell extends GateRenderer[SequentialGatePart] {
   val pointer = new PointerModel(13, 8, 8)
 
   override val coreModels =
-    wires ++ torches ++ Seq(chip, new BaseComponentModel)
+    wires ++ torches ++ Seq(chip, BaseComponentModel.model)
 
   override def prepareInv() {
     reflect = false
@@ -931,7 +931,7 @@ class RenderSynchronizer extends GateRenderer[SequentialGatePart] {
   val torch = new RedstoneTorchModel(8, 3, 6)
   val chips = Seq(new RedChipModel(4.5, 9), new RedChipModel(11.5, 9))
 
-  override val coreModels = wires ++ chips ++ Seq(torch, new BaseComponentModel)
+  override val coreModels = wires ++ chips ++ Seq(torch, BaseComponentModel.model)
 
   override def prepareInv() {
     wires(0).on = true
@@ -968,7 +968,7 @@ class RenderBusXcvr extends GateRenderer[BundledGatePart] {
   val cable = new BusXcvrCableModel
 
   override val coreModels =
-    wires ++ panels ++ Seq(cable, new BaseComponentModel)
+    wires ++ panels ++ Seq(cable, BaseComponentModel.model)
 
   override def prepareInv() {
     reflect = false
@@ -997,7 +997,7 @@ class RenderComparator extends GateRenderer[SequentialGatePart] {
   val torch = new RedstoneTorchModel(8, 2, 6)
   val chips = Seq(new MinusChipModel(5, 8), new PlusChipModel(11, 8))
 
-  override val coreModels = wires ++ Seq(torch, new BaseComponentModel)
+  override val coreModels = wires ++ Seq(torch, BaseComponentModel.model)
 
   override def prepareInv() {
     reflect = false
@@ -1044,7 +1044,7 @@ class RenderBusRandomizer extends GateRenderer[BundledGatePart] {
   panel.offColour = 0x756900ff
   panel.onColour = 0xe1d600ff
 
-  override val coreModels = Seq(cable, panel, new BaseComponentModel)
+  override val coreModels = Seq(cable, panel, BaseComponentModel.model)
 
   override def switchModels = if (shape == 0) wires1 else wires2
   override def allSwitchModels = wires1 ++ wires2
@@ -1078,7 +1078,7 @@ class RenderBusConverter extends GateRenderer[BundledGatePart] {
   val cable = new BusConvCableModel
   val bar = new SignalBarModel(8, 8)
 
-  override val coreModels = wires ++ Seq(cable, bar, new BaseComponentModel)
+  override val coreModels = wires ++ Seq(cable, bar, BaseComponentModel.model)
 
   override def prepareInv() {
     wires(0).on = false
@@ -1103,7 +1103,7 @@ class RenderBusInputPanel extends GateRenderer[BundledGatePart] {
   val buttons = new InputPanelButtonsModel
   val cable = new BusInputPanelCableModel
 
-  override val coreModels = wires ++ Seq(buttons, cable, new BaseComponentModel)
+  override val coreModels = wires ++ Seq(buttons, cable, BaseComponentModel.model)
 
   override def prepareInv() {
     wires(0).on = false
@@ -1238,7 +1238,7 @@ class RenderANDCell extends GateRenderer[ArrayGatePart] {
   val topWire = new CellTopWireModel(nullCellWireTop)
 
   override val coreModels =
-    wires ++ torches ++ Seq(topWire, new CellFrameModel, new BaseComponentModel)
+    wires ++ torches ++ Seq(topWire, new CellFrameModel, BaseComponentModel.model)
 
   override def prepareInv() {
     topWire.signal = 0
@@ -1276,7 +1276,7 @@ class RenderStackingLatch extends GateRenderer[ArrayGatePart] {
     clkwire,
     new StackLatchStandModel(3.5, 5),
     new StackLatchStandModel(12.5, 5),
-    new BaseComponentModel
+    BaseComponentModel.model
   )
 
   override def prepareInv() {
@@ -1315,7 +1315,7 @@ class RenderSegmentDisplay extends GateRenderer[BundledGatePart] {
   var shape = 0
 
   override val coreModels =
-    Seq(new SegmentBusCableModel, new BaseComponentModel)
+    Seq(new SegmentBusCableModel, BaseComponentModel.model)
   override def switchModels =
     if (shape == 0) Seq(sevenSeg0, sevenSeg1) else Seq(sixteenSeg)
   override def allSwitchModels = Seq(sevenSeg0, sevenSeg1, sixteenSeg)
@@ -1356,7 +1356,7 @@ class RenderDecodingRand extends GateRenderer[ComboGatePart] {
     new RedstoneTorchModel(9, 8, 6)
   )
 
-  override val coreModels = wires ++ chips ++ torches :+ new BaseComponentModel
+  override val coreModels = wires ++ chips ++ torches :+ BaseComponentModel.model
 
   override def prepareInv() {
     wires(0).on = false

--- a/src/main/scala/mrtjp/projectred/integration/gaterenders.scala
+++ b/src/main/scala/mrtjp/projectred/integration/gaterenders.scala
@@ -931,7 +931,8 @@ class RenderSynchronizer extends GateRenderer[SequentialGatePart] {
   val torch = new RedstoneTorchModel(8, 3, 6)
   val chips = Seq(new RedChipModel(4.5, 9), new RedChipModel(11.5, 9))
 
-  override val coreModels = wires ++ chips ++ Seq(torch, BaseComponentModel.model)
+  override val coreModels =
+    wires ++ chips ++ Seq(torch, BaseComponentModel.model)
 
   override def prepareInv() {
     wires(0).on = true
@@ -1103,7 +1104,8 @@ class RenderBusInputPanel extends GateRenderer[BundledGatePart] {
   val buttons = new InputPanelButtonsModel
   val cable = new BusInputPanelCableModel
 
-  override val coreModels = wires ++ Seq(buttons, cable, BaseComponentModel.model)
+  override val coreModels =
+    wires ++ Seq(buttons, cable, BaseComponentModel.model)
 
   override def prepareInv() {
     wires(0).on = false
@@ -1238,7 +1240,11 @@ class RenderANDCell extends GateRenderer[ArrayGatePart] {
   val topWire = new CellTopWireModel(nullCellWireTop)
 
   override val coreModels =
-    wires ++ torches ++ Seq(topWire, new CellFrameModel, BaseComponentModel.model)
+    wires ++ torches ++ Seq(
+      topWire,
+      new CellFrameModel,
+      BaseComponentModel.model
+    )
 
   override def prepareInv() {
     topWire.signal = 0
@@ -1356,7 +1362,8 @@ class RenderDecodingRand extends GateRenderer[ComboGatePart] {
     new RedstoneTorchModel(9, 8, 6)
   )
 
-  override val coreModels = wires ++ chips ++ torches :+ BaseComponentModel.model
+  override val coreModels =
+    wires ++ chips ++ torches :+ BaseComponentModel.model
 
   override def prepareInv() {
     wires(0).on = false


### PR DESCRIPTION
Refer to #77 for a more detailed explanation. This PR also fixes an issue where a uv transformation became a coordinate transformation in one code path in the previous PR.