### PR TITLE
[Memory-opti:fix leak] fix world client leak caused by light matrix

### DIFF
--- a/src/main/scala/mrtjp/projectred/exploration/renders.scala
+++ b/src/main/scala/mrtjp/projectred/exploration/renders.scala
@@ -165,6 +165,7 @@ object RenderLily extends TInstancedBlockRender {
           new IconTransformation(iconC),
           new ColourMultiplier(Colors(te.meta).rgba)
         )
+      state.lightMatrix.access = null;
     }
   }
 

--- a/src/main/scala/mrtjp/projectred/fabrication/tileicprinter.scala
+++ b/src/main/scala/mrtjp/projectred/fabrication/tileicprinter.scala
@@ -673,6 +673,7 @@ object RenderICPrinter extends TInstancedBlockRender {
       * with screwdriver to see the issue.
       */
     // lowerBoxes(0).render(Rotation.quarterRotations(tile.rotation) at Vector3.center `with` new Translation(x, y, z), iconT, CCRenderState.lightMatrix)
+    state.lightMatrix.access = null
   }
 
   override def getIcon(side: Int, meta: Int) = side match {


### PR DESCRIPTION
<img width="469" height="144" alt="image" src="https://github.com/user-attachments/assets/158aacd4-04a8-4641-bc2d-67ac3248215d" />
