### PR TITLE
Fix ProjectRed wires not providing redstone power

### DIFF
--- a/src/main/scala/mrtjp/projectred/transmission/propagation.scala
+++ b/src/main/scala/mrtjp/projectred/transmission/propagation.scala
@@ -27,8 +27,8 @@ object WirePropagator {
     catch { case t: Throwable => }
   }
 
-  private val rwConnectable = {
-    val b = new ThreadLocal[Boolean]; b.set(true); b
+  private val rwConnectable = new ThreadLocal[Boolean] {
+    override def initialValue(): Boolean = true
   }
 
   def redwiresConnectable = rwConnectable.get


### PR DESCRIPTION
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24634
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24592

rwConnectable is a ThreadLocal that was only initialized on the client thread. The server thread got false by default, causing canConnectRedstone() to always return false, so wires never provided power. The fix uses initialValue() to ensure every thread gets true as the default.