### PR TITLE
Fix devices voiding internal buffer when loading world

### DIFF
--- a/src/main/scala/mrtjp/projectred/expansion/deviceabstracts.scala
+++ b/src/main/scala/mrtjp/projectred/expansion/deviceabstracts.scala
@@ -53,7 +53,7 @@ class ItemStorage {
   }
 
   def load(tag: NBTTagCompound) {
-    val nbttaglist = tag.getTagList("itemFlow", 0)
+    val nbttaglist = tag.getTagList("itemFlow", 10)
     for (j <- 0 until nbttaglist.tagCount) {
       try {
         val payloadData = nbttaglist.getCompoundTagAt(j)


### PR DESCRIPTION
Fixes GTNewHorizons/GT-New-Horizons-Modpack#25041

Fixes devices voiding items in the backlog/buffer upon world/server reloads.
The itemFlow NBT tags were not being loaded properly.