### PR TITLE
make inductive furnace configurable

### DIFF
--- a/src/main/scala/mrtjp/projectred/core/Configurator.scala
+++ b/src/main/scala/mrtjp/projectred/core/Configurator.scala
@@ -33,6 +33,7 @@ object Configurator extends ModConfig("ProjRed|Core") {
   var enchantment_fuel_efficiencty_id = 80
 
   /** Machines * */
+  var enableInductiveFurnace = true
   var enableDiamondBlockBreaker = false
 
   /** Rendering * */
@@ -149,6 +150,11 @@ object Configurator extends ModConfig("ProjRed|Core") {
     val machines = new BaseCategory(
       "Machine Settings",
       "Contains settings related to machines and devices."
+    )
+    enableInductiveFurnace = machines.put(
+      "Enable the Inductive Furnace",
+      enableInductiveFurnace,
+      "Allow the Inductive Furnace to be crafted and load its smelting recipes."
     )
     enableDiamondBlockBreaker = machines.put(
       "Enable the Diamond Block Breaker",

--- a/src/main/scala/mrtjp/projectred/expansion/proxies.scala
+++ b/src/main/scala/mrtjp/projectred/expansion/proxies.scala
@@ -169,7 +169,7 @@ object ForwardClientTracker extends TClientKeyTracker {
 
 object ExpansionRecipes {
   def initRecipes() {
-    InductiveFurnaceRecipeLib.init()
+    if (Configurator.enableInductiveFurnace) InductiveFurnaceRecipeLib.init()
     initItemRecipes()
     initMachineRecipes()
     initDeviceRecipes()
@@ -235,20 +235,22 @@ object ExpansionRecipes {
 
   private def initMachineRecipes() {
     // Inductive Furnace
-    GameRegistry.addRecipe(
-      new ShapedOreRecipe(
-        new ItemStack(machine1, 1, 0),
-        "bbb",
-        "b b",
-        "iei",
-        'b': JC,
-        Blocks.brick_block,
-        'i': JC,
-        "ingotIron",
-        'e': JC,
-        "ingotElectrotineAlloy"
+    if (Configurator.enableInductiveFurnace) {
+      GameRegistry.addRecipe(
+        new ShapedOreRecipe(
+          new ItemStack(machine1, 1, 0),
+          "bbb",
+          "b b",
+          "iei",
+          'b': JC,
+          Blocks.brick_block,
+          'i': JC,
+          "ingotIron",
+          'e': JC,
+          "ingotElectrotineAlloy"
+        )
       )
-    )
+    }
 
     // Electrotine generator
     GameRegistry.addRecipe(


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Turns out this furnace is spamming the oredict queries somehow to duplicate vanilla smelting recipes while adding it oredict support. Since it is not used in NH i added a config so we can simply turn it off in the modpack. Default true so we preserve compat with external envs, as ProjectRed is supported outside NH.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [ ] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
