### PR TITLE
Fixed the IC Printer circutry space (#26337)

### DIFF
--- a/src/main/scala/mrtjp/projectred/fabrication/tileicprinter.scala
+++ b/src/main/scala/mrtjp/projectred/fabrication/tileicprinter.scala
@@ -473,9 +473,9 @@ object TileICPrinter {
       case p: ButtonICPart    => add(new ItemStack(Blocks.stone_button), 0.25)
       case p: AlloyWireICPart => add(WireDef.RED_ALLOY.makeStack, 0.25)
       case p: InsulatedWireICPart =>
-        add(WireDef.INSULATED_WIRES(p.colour & 0xff).makeStack, 0.25)
+        add(WireDef.INSULATED_WIRES(15).makeStack, 0.25)
       case p: BundledCableICPart =>
-        add(WireDef.BUNDLED_WIRES((p.colour + 1) & 0xff).makeStack, 0.25)
+        add(WireDef.BUNDLED_WIRES(0).makeStack, 0.25)
       case p: GateICPart =>
         gd.apply(p.subID) match {
           case gd.IOSimple =>


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->

Closes (#26337)

This pr makes every cable back or default so the printer has enough space but in the chip the cables get printed in different colors.

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
