### PR TITLE
Fix ProjectRed Crafting Chip with no output item can cause NPE

### DIFF
--- a/src/main/scala/mrtjp/projectred/transportation/ChipCrafting.scala
+++ b/src/main/scala/mrtjp/projectred/transportation/ChipCrafting.scala
@@ -261,7 +261,8 @@ class ChipCrafting
   }
 
   override def registerExcess(promise: DeliveryPromise) {
-    if (getCraftedItem.key == promise.item)
+    val craftedItem = getCraftedItem
+    if (craftedItem != null && craftedItem.key == promise.item)
       excess += promise.item -> promise.size
   }
 


### PR DESCRIPTION
## Summary
When a crafting chip has no output item `ChipCrafting.getCraftedItem` returns null, which is supported on all callers but `ChipCrafting.registerExcess`. This causes a NPE leading to a server crash when a stock keeper chip requests an item in the same network

fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/23881
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/22401

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
